### PR TITLE
Add third argument to FontFace contructor, fix #2

### DIFF
--- a/woff2.js
+++ b/woff2.js
@@ -3,7 +3,7 @@ var supportsWoff2 = (function( win ){
 		return false;
 	}
 
-	var f = new win.FontFace( "t", 'url( "data:application/font-woff2," ) format( "woff2" )' );
+	var f = new win.FontFace( "t", 'url( "data:application/font-woff2," ) format( "woff2" )', {} );
 	f.load();
 
 	return f.status == 'loading';


### PR DESCRIPTION
This argument, `FontFaceDescriptors`, is optional according to spec but
causes some browsers (Chrome 35 and 36, Opera 22 and 23) to throw an
error.

```
Uncaught TypeError: Failed to construct 'FontFace': 3 arguments required, but only 2 present.
```
