### PR TITLE
"catch" method of the load() promise is causing IE8 to trow a syntax error

### DIFF
--- a/woff2.js
+++ b/woff2.js
@@ -4,7 +4,7 @@ var supportsWoff2 = (function( win ){
 	}
 
 	var f = new win.FontFace( "t", 'url( "data:application/font-woff2," ) format( "woff2" )', {} );
-	f.load().catch(function() {});
+	f.load()['catch'](function() {});
 
 	return f.status == 'loading';
 })( this );


### PR DESCRIPTION
I changed the syntax for calling the catch method to array notation, so IE8 doesn't complain about the way of using this reserved word.

This doesn't always happens, I've managed to reproduce the error when pasting the code from woff2.js into the HTML document itself. Also sometimes on some IE8 runing on virtual machines.

I wonder why the promises API use the catch keyword without backwards compatibility.
![image](https://cloud.githubusercontent.com/assets/836077/9292941/32d78db0-4414-11e5-99e8-a89360583634.png)
