### PR TITLE
Make compatible with strict mode by using window directly, removing `this` binding  

### DIFF
--- a/woff2.js
+++ b/woff2.js
@@ -1,5 +1,5 @@
-var supportsWoff2 = (function( win ){
-	if( !( "FontFace" in win ) ) {
+var supportsWoff2 = (function(){
+	if( !( "FontFace" in window ) ) {
 		return false;
 	}
 
@@ -7,4 +7,4 @@ var supportsWoff2 = (function( win ){
 	f.load()['catch'](function() {});
 
 	return f.status == 'loading' || f.status == 'loaded';
-})( this );
+})();


### PR DESCRIPTION
The issue I had when accidentally prepending `use strict` to the feature test file had to do with the default argument `win` being undefined. Iterating over window directly works with `use strict`, and I _believe_ is functionally equivalent. 

Full disclosure, I don't know if there are ancient or mobile browser edge cases that this would fail in, or the level of low percentage browser support you're looking to provide. Thoughts? From my point of view this is a little more direct and less fancy.
